### PR TITLE
Update error in next/prev handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -54,6 +54,10 @@ func (m model) next(writer http.ResponseWriter, request *http.Request) {
 				}
 				log.Println("Something went wrong accessing '" + dest + "', skipping site")
 			}
+			http.Error(writer, `It would appear that either none of the ring members are accessible
+(unlikely) or the backend is broken (more likely). In either case,
+please contact the admin and let them know what's up.`, 500)
+			return
 		}
 	}
 	if success == false {
@@ -95,7 +99,7 @@ func (m model) previous(writer http.ResponseWriter, request *http.Request) {
 			}
 			http.Error(writer, `It would appear that either none of the ring members are accessible
 (unlikely) or the backend is broken (more likely). In either case,
-please email amolith@secluded.site and let him (me) know what's up.`, 500)
+please contact the admin and let them know what's up.`, 500)
 			return
 		}
 	}


### PR DESCRIPTION
When no redirect is performed, the previous handler displays an error saying to email my personal email address. This PR adds that functionality to the next handler and replaces my personal email address with a generic "contact the admin" phrase.

I'll eventually move this to the flags in upstream, but in the meantime, I just didn't want my email address to show up on your instance.